### PR TITLE
Fix black formatting and flake8 linting errors

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -17,6 +17,6 @@ from .state import FinancialOrchestratorState, create_initial_state
 
 __all__ = [
     "financial_orchestrator",
-    "FinancialOrchestratorState", 
-    "create_initial_state"
+    "FinancialOrchestratorState",
+    "create_initial_state",
 ]

--- a/scripts/test_deployment.py
+++ b/scripts/test_deployment.py
@@ -131,6 +131,7 @@ def test_local_imports() -> bool:
         # Test core imports one by one for better error reporting
         try:
             from agents.state import create_initial_state
+
             print("  ✅ agents.state imported")
         except ImportError as e:
             print(f"  ❌ agents.state import failed: {e}")
@@ -138,6 +139,7 @@ def test_local_imports() -> bool:
 
         try:
             from agents.graph import financial_orchestrator
+
             print("  ✅ agents.graph imported")
         except ImportError as e:
             print(f"  ❌ agents.graph import failed: {e}")
@@ -145,6 +147,7 @@ def test_local_imports() -> bool:
 
         try:
             from config.settings import configure_pandas
+
             print("  ✅ config.settings imported")
         except ImportError as e:
             print(f"  ❌ config.settings import failed: {e}")
@@ -152,6 +155,7 @@ def test_local_imports() -> bool:
 
         try:
             from utils.error_handling import setup_logging
+
             print("  ✅ utils.error_handling imported")
         except ImportError as e:
             print(f"  ❌ utils.error_handling import failed: {e}")


### PR DESCRIPTION
- Fixed black formatting issues in scripts/test_deployment.py by adding proper spacing between import statements and print statements
- Fixed trailing comma and spacing issues in agents/__init__.py
- Reformatted analysis_bot_original_backup.py to comply with black standards
- Fixed bare except clause in analysis_bot_original_backup.py to use Exception instead

All files now pass black --check and flake8 linting requirements.